### PR TITLE
Add human readable output flag

### DIFF
--- a/bin/duc
+++ b/bin/duc
@@ -22,11 +22,16 @@ if __name__ == '__main__':
         prog='duc',
         description='Disk Usage (Cached) [disktools ver. %s]' %
                     disktools_version,
+        add_help=False,
     )
     parser.add_argument('path', type=str,
                         help='Get size of specified path.')
     parser.add_argument('--purge', action='store_true',
                         help='Purge and remove all the cache.')
+    parser.add_argument('-h', '--human', action='store_true',
+                        help='Human-readable output (e.g., 1.1K, 234M)')
+    parser.add_argument('--help', action='help',
+                        help='Show this help message and exit')
     args = parser.parse_args()
 
     if not os.path.exists(args.path):
@@ -39,4 +44,19 @@ if __name__ == '__main__':
         exit()
 
     size = duc(args.path)
-    print('%d\t%s' % (size, args.path))
+    if args.human:
+        # replicate the humanize formatting from cli.py to keep this script standalone
+        def _humanize_bytes(num):
+            base = 1024.0
+            units = ['B', 'K', 'M', 'G', 'T', 'P', 'E', 'Z', 'Y']
+            value = float(num)
+            for unit in units:
+                if value < base or unit == units[-1]:
+                    if unit == 'B':
+                        return '%dB' % int(num)
+                    return '%.1f%s' % (value, unit)
+                value /= base
+
+        print('%s\t%s' % (_humanize_bytes(size), args.path))
+    else:
+        print('%d\t%s' % (size, args.path))

--- a/src/disktools/cli.py
+++ b/src/disktools/cli.py
@@ -6,13 +6,28 @@ from disktools import __version__ as disktools_version
 from disktools.disk_usage import get_size, purge_rec_cache
 
 
+def humanize_bytes(num):
+    base = 1024.0
+    units = ['B', 'K', 'M', 'G', 'T', 'P', 'E', 'Z', 'Y']
+    value = float(num)
+    for unit in units:
+        if value < base or unit == units[-1]:
+            if unit == 'B':
+                return '%dB' % int(num)
+            return '%.1f%s' % (value, unit)
+        value /= base
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(
         prog='duc',
         description='Disk Usage (Cached) [disktools ver. %s]' % disktools_version,
+        add_help=False,
     )
     parser.add_argument('path', type=str, help='Get size of specified path.')
     parser.add_argument('--purge', action='store_true', help='Purge and remove all the cache.')
+    parser.add_argument('-h', '--human', action='store_true', help='Human-readable output (e.g., 1.1K, 234M)')
+    parser.add_argument('--help', action='help', help='Show this help message and exit')
     args = parser.parse_args()
 
     if not os.path.exists(args.path):
@@ -24,7 +39,10 @@ def main() -> None:
         return
 
     size = get_size(args.path)
-    print('%d\t%s' % (size, args.path))
+    if args.human:
+        print('%s\t%s' % (humanize_bytes(size), args.path))
+    else:
+        print('%d\t%s' % (size, args.path))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Add `-h` / `--human` flag to display disk usage in human-readable format.

---
<a href="https://cursor.com/background-agent?bcId=bc-c2ee112f-adeb-4e78-b202-5349033c2998">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c2ee112f-adeb-4e78-b202-5349033c2998">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

