### PR TITLE
Add human readable output flag

### DIFF
--- a/bin/duc
+++ b/bin/duc
@@ -17,16 +17,32 @@ def duc(path):
     return get_size(path)
 
 
+def _format_human_readable_size(num_bytes):
+    units = ['B', 'K', 'M', 'G', 'T', 'P', 'E', 'Z', 'Y']
+    size = float(num_bytes)
+    for unit in units:
+        if size < 1024.0 or unit == 'Y':
+            if unit == 'B':
+                return '%dB' % num_bytes
+            return '%.1f%s' % (size, unit)
+        size = size / 1024.0
+
+
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(
         prog='duc',
         description='Disk Usage (Cached) [disktools ver. %s]' %
                     disktools_version,
+        add_help=False,
     )
     parser.add_argument('path', type=str,
                         help='Get size of specified path.')
     parser.add_argument('--purge', action='store_true',
                         help='Purge and remove all the cache.')
+    parser.add_argument('-h', '--human', dest='human', action='store_true',
+                        help='Print human readable sizes (e.g. 1.1K, 234M).')
+    parser.add_argument('--help', action='help',
+                        help='Show this help message and exit.')
     args = parser.parse_args()
 
     if not os.path.exists(args.path):
@@ -39,4 +55,7 @@ if __name__ == '__main__':
         exit()
 
     size = duc(args.path)
-    print('%d\t%s' % (size, args.path))
+    if args.human:
+        print('%s\t%s' % (_format_human_readable_size(size), args.path))
+    else:
+        print('%d\t%s' % (size, args.path))

--- a/src/disktools/cli.py
+++ b/src/disktools/cli.py
@@ -6,13 +6,29 @@ from disktools import __version__ as disktools_version
 from disktools.disk_usage import get_size, purge_rec_cache
 
 
+def _format_human_readable_size(num_bytes):
+    units = ['B', 'K', 'M', 'G', 'T', 'P', 'E', 'Z', 'Y']
+    size = float(num_bytes)
+    for unit in units:
+        if size < 1024.0 or unit == 'Y':
+            if unit == 'B':
+                return '%dB' % num_bytes
+            return '%.1f%s' % (size, unit)
+        size = size / 1024.0
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(
         prog='duc',
         description='Disk Usage (Cached) [disktools ver. %s]' % disktools_version,
+        add_help=False,
     )
     parser.add_argument('path', type=str, help='Get size of specified path.')
     parser.add_argument('--purge', action='store_true', help='Purge and remove all the cache.')
+    parser.add_argument('-h', '--human', dest='human', action='store_true',
+                        help='Print human readable sizes (e.g. 1.1K, 234M).')
+    parser.add_argument('--help', action='help',
+                        help='Show this help message and exit.')
     args = parser.parse_args()
 
     if not os.path.exists(args.path):
@@ -24,7 +40,10 @@ def main() -> None:
         return
 
     size = get_size(args.path)
-    print('%d\t%s' % (size, args.path))
+    if args.human:
+        print('%s\t%s' % (_format_human_readable_size(size), args.path))
+    else:
+        print('%d\t%s' % (size, args.path))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Add `-h/--human` flag to display disk usage in human-readable format.

---
<a href="https://cursor.com/background-agent?bcId=bc-7dc4e833-071c-4933-8e3e-a1618298663c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7dc4e833-071c-4933-8e3e-a1618298663c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

